### PR TITLE
Add spike obstacle that kills and respawns Chip

### DIFF
--- a/scenes/Levels/level_obstacle_test.tscn
+++ b/scenes/Levels/level_obstacle_test.tscn
@@ -3,6 +3,8 @@
 [ext_resource type="Texture2D" uid="uid://wj83h8605qyi" path="res://art/Images/Tilemaps/Terrain (16x16).png" id="1_ix3yw"]
 [ext_resource type="PackedScene" uid="uid://cyfopgcmsew45" path="res://scenes/player.tscn" id="2_5hi2o"]
 [ext_resource type="PackedScene" uid="uid://dwall00001" path="res://scenes/obstacles/wall.tscn" id="3_wall"]
+[ext_resource type="PackedScene" path="res://scenes/obstacles/spike.tscn" id="4_r5d3n"]
+[ext_resource type="PackedScene" path="res://scenes/respawn_point.tscn" id="5_y2ehk"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_5hi2o"]
 texture = ExtResource("1_ix3yw")
@@ -180,4 +182,15 @@ position = Vector2(640, 630)
 [node name="MaskableBehavior" parent="Wall" index="0"]
 invert_logic = true
 
+[node name="Spike" parent="." unique_id=907950423 instance=ExtResource("4_r5d3n")]
+position = Vector2(486, 518)
+rotation = -1.5707964
+
+[node name="MaskableBehavior" parent="Spike" index="0"]
+bit_index = 1
+
+[node name="RespawnPoint" parent="." unique_id=1263991365 instance=ExtResource("5_y2ehk")]
+position = Vector2(153, 520)
+
 [editable path="Wall"]
+[editable path="Spike"]

--- a/scenes/obstacles/spike.tscn
+++ b/scenes/obstacles/spike.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/spike.gd" id="1_spike"]
+[ext_resource type="Script" uid="uid://be1x5xk2wnhi8" path="res://scripts/maskable_behavior.gd" id="2_maskable"]
+
+[node name="Spike" type="Area2D"]
+collision_layer = 0
+collision_mask = 1
+script = ExtResource("1_spike")
+
+[node name="MaskableBehavior" type="Node" parent="."]
+script = ExtResource("2_maskable")
+
+[node name="Sprite" type="Polygon2D" parent="."]
+color = Color(0.8, 0.1, 0.1, 1)
+polygon = PackedVector2Array(0, -64, 32, 0, -32, 0)
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+polygon = PackedVector2Array(0, -64, 32, 0, -32, 0)

--- a/scenes/respawn_point.tscn
+++ b/scenes/respawn_point.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/respawn_point.gd" id="1_respawn"]
+
+[node name="RespawnPoint" type="Marker2D"]
+script = ExtResource("1_respawn")

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -50,6 +50,27 @@ var chip_health: int = 3:
 
 var chip_max_health: int = 3
 
+# --- Respawn ---
+var _respawn_point: Node2D = null
+var _player: CharacterBody2D = null
+
+func register_respawn_point(point: Node2D) -> void:
+	_respawn_point = point
+
+func register_player(player: CharacterBody2D) -> void:
+	_player = player
+
+func get_respawn_position() -> Vector2:
+	if _respawn_point:
+		return _respawn_point.global_position
+	push_warning("GameManager: No respawn point registered, using origin")
+	return Vector2.ZERO
+
+func kill_chip() -> void:
+	chip_died.emit()
+	if _player and _player.has_method("respawn"):
+		_player.respawn(get_respawn_position())
+
 # --- Progress ---
 var current_level: int = 1
 

--- a/scripts/respawn_point.gd
+++ b/scripts/respawn_point.gd
@@ -1,0 +1,5 @@
+class_name RespawnPoint
+extends Marker2D
+
+func _ready() -> void:
+	GameManager.register_respawn_point(self)

--- a/scripts/spike.gd
+++ b/scripts/spike.gd
@@ -1,0 +1,13 @@
+class_name Spike
+extends Area2D
+
+func _ready() -> void:
+	body_entered.connect(_on_body_entered)
+
+func on_bit_changed(enabled: bool) -> void:
+	visible = enabled
+	monitoring = enabled
+
+func _on_body_entered(body: Node2D) -> void:
+	if body.has_method("die"):
+		body.die()


### PR DESCRIPTION
## Summary

- Add Spike obstacle scene with MaskableBehavior for bitmask-controlled toggling
- Add RespawnPoint marker node for defining player spawn locations
- Implement death/respawn system with visual feedback (red flash → fade out → teleport → fade in)
- Extend GameManager with kill_chip() and respawn registration

## Related Issue

Closes #8