### PR TITLE
Add checkpoint system

### DIFF
--- a/scenes/Levels/level_obstacle_test.tscn
+++ b/scenes/Levels/level_obstacle_test.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://dwall00001" path="res://scenes/obstacles/wall.tscn" id="3_wall"]
 [ext_resource type="PackedScene" path="res://scenes/obstacles/spike.tscn" id="4_r5d3n"]
 [ext_resource type="PackedScene" path="res://scenes/respawn_point.tscn" id="5_y2ehk"]
+[ext_resource type="PackedScene" path="res://scenes/checkpoint.tscn" id="6_cfpkn"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_5hi2o"]
 texture = ExtResource("1_ix3yw")
@@ -183,7 +184,7 @@ position = Vector2(640, 630)
 invert_logic = true
 
 [node name="Spike" parent="." unique_id=907950423 instance=ExtResource("4_r5d3n")]
-position = Vector2(486, 518)
+position = Vector2(1165, 540)
 rotation = -1.5707964
 
 [node name="MaskableBehavior" parent="Spike" index="0"]
@@ -192,5 +193,17 @@ bit_index = 1
 [node name="RespawnPoint" parent="." unique_id=1263991365 instance=ExtResource("5_y2ehk")]
 position = Vector2(153, 520)
 
+[node name="Checkpoint" parent="." unique_id=233084375 instance=ExtResource("6_cfpkn")]
+position = Vector2(876.99994, 670)
+scale = Vector2(2.5125513, 3.0697668)
+
+[node name="Spike2" parent="." unique_id=501160674 instance=ExtResource("4_r5d3n")]
+position = Vector2(453, 552)
+rotation = -1.560763
+
+[node name="MaskableBehavior" parent="Spike2" index="0"]
+bit_index = 1
+
 [editable path="Wall"]
 [editable path="Spike"]
+[editable path="Spike2"]

--- a/scenes/checkpoint.tscn
+++ b/scenes/checkpoint.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/checkpoint.gd" id="1_checkpoint"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_1"]
+size = Vector2(32, 64)
+
+[node name="Checkpoint" type="Area2D"]
+z_index = -1
+collision_layer = 0
+collision_mask = 1
+script = ExtResource("1_checkpoint")
+
+[node name="Pole" type="Polygon2D" parent="."]
+color = Color(0.4, 0.4, 0.5, 1)
+polygon = PackedVector2Array(-4, 0, 4, 0, 4, -64, -4, -64)
+
+[node name="Flag" type="Polygon2D" parent="."]
+color = Color(0.5, 0.5, 0.6, 1)
+polygon = PackedVector2Array(-4, -64, 32, -48, -4, -32)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -32)
+shape = SubResource("RectangleShape2D_1")

--- a/scripts/checkpoint.gd
+++ b/scripts/checkpoint.gd
@@ -1,0 +1,29 @@
+class_name Checkpoint
+extends Area2D
+## Checkpoint that updates the respawn point when the player touches it.
+## Place in levels to provide save points during gameplay.
+
+@onready var flag: Polygon2D = $Flag
+
+var _activated := false
+
+func _ready() -> void:
+	body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node2D) -> void:
+	if _activated:
+		return
+
+	# Check if it's the player
+	if body.has_method("die"):
+		_activate()
+
+func _activate() -> void:
+	_activated = true
+	GameManager.register_respawn_point(self)
+
+	# Visual feedback - change flag to green
+	var tween = create_tween()
+	tween.tween_property(flag, "color", Color(0.2, 0.9, 0.3, 1.0), 0.2)
+	tween.parallel().tween_property(flag, "scale", Vector2(1.2, 1.2), 0.1)
+	tween.tween_property(flag, "scale", Vector2(1.0, 1.0), 0.1)

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -10,6 +10,7 @@ signal chip_health_changed(new_health: int)
 signal chip_died
 signal level_completed
 signal max_bits_changed(new_max: int)
+signal checkpoint_activated(checkpoint: Node2D)
 
 # --- Bitmask State ---
 ## The current bitmask controlling level objects.
@@ -36,7 +37,8 @@ var max_bits: int = 4:
 		max_bits_changed.emit(max_bits)
 
 # --- Object Registry ---
-## Maps bit_index -> registered object (Node)
+## Maps bit_index -> Array of registered objects (Nodes)
+## Multiple objects can share the same bit index.
 ## Objects must implement: on_bit_changed(enabled: bool)
 var _registered_objects: Dictionary = {}
 
@@ -52,10 +54,18 @@ var chip_max_health: int = 3
 
 # --- Respawn ---
 var _respawn_point: Node2D = null
+var _initial_respawn_point: Node2D = null
 var _player: CharacterBody2D = null
 
-func register_respawn_point(point: Node2D) -> void:
+## Register a respawn point. If is_initial is true, also stores as the initial
+## spawn point for level resets.
+func register_respawn_point(point: Node2D, is_initial: bool = false) -> void:
 	_respawn_point = point
+	if is_initial:
+		_initial_respawn_point = point
+	elif _initial_respawn_point != null and point != _initial_respawn_point:
+		# This is a checkpoint activation
+		checkpoint_activated.emit(point)
 
 func register_player(player: CharacterBody2D) -> void:
 	_player = player
@@ -70,6 +80,12 @@ func kill_chip() -> void:
 	chip_died.emit()
 	if _player and _player.has_method("respawn"):
 		_player.respawn(get_respawn_position())
+
+## Reset the respawn point to the initial spawn point.
+## Call this on level reset to clear checkpoint progress.
+func reset_checkpoints() -> void:
+	if _initial_respawn_point:
+		_respawn_point = _initial_respawn_point
 
 # --- Progress ---
 var current_level: int = 1
@@ -113,57 +129,91 @@ func get_binary_string() -> String:
 
 ## Register an object to a specific bit index.
 ## The object should implement: on_bit_changed(enabled: bool)
-## Returns true if registration succeeded, false if bit already taken.
+## Multiple objects can register to the same bit index.
 func register_object(bit_index: int, object: Node) -> bool:
 	if bit_index < 0 or bit_index >= max_bits:
 		push_error("GameManager: bit_index %d out of range (0-%d)" % [bit_index, max_bits - 1])
 		return false
 
-	if _registered_objects.has(bit_index):
-		push_warning("GameManager: bit %d already has a registered object, replacing" % bit_index)
+	# Create array for this bit if it doesn't exist
+	if not _registered_objects.has(bit_index):
+		_registered_objects[bit_index] = []
 
-	_registered_objects[bit_index] = object
+	# Add object to the array (avoid duplicates)
+	var objects_array: Array = _registered_objects[bit_index]
+	if object not in objects_array:
+		objects_array.append(object)
 
-	# Immediately notify the object of current state
-	_notify_registered_object(bit_index, is_bit_set(bit_index))
+	# Immediately notify this object of current state
+	if object.has_method("on_bit_changed"):
+		object.on_bit_changed(is_bit_set(bit_index))
 
 	# Auto-unregister when object is freed
-	if not object.tree_exiting.is_connected(_on_registered_object_exiting.bind(bit_index)):
-		object.tree_exiting.connect(_on_registered_object_exiting.bind(bit_index))
+	var cleanup_callable = _on_registered_object_exiting.bind(bit_index, object)
+	if not object.tree_exiting.is_connected(cleanup_callable):
+		object.tree_exiting.connect(cleanup_callable)
 
 	return true
 
-## Unregister an object from its bit index.
-func unregister_object(bit_index: int) -> void:
-	_registered_objects.erase(bit_index)
+## Unregister a specific object from its bit index.
+func unregister_object(bit_index: int, object: Node = null) -> void:
+	if not _registered_objects.has(bit_index):
+		return
 
-## Get the object registered to a bit index (or null).
+	if object == null:
+		# Remove all objects at this bit index
+		_registered_objects.erase(bit_index)
+	else:
+		# Remove specific object from array
+		var objects_array: Array = _registered_objects[bit_index]
+		objects_array.erase(object)
+		# Clean up empty arrays
+		if objects_array.is_empty():
+			_registered_objects.erase(bit_index)
+
+## Get the first object registered to a bit index (or null).
 func get_registered_object(bit_index: int) -> Node:
-	return _registered_objects.get(bit_index)
+	if not _registered_objects.has(bit_index):
+		return null
+	var objects_array: Array = _registered_objects[bit_index]
+	if objects_array.is_empty():
+		return null
+	return objects_array[0]
+
+## Get all objects registered to a bit index.
+func get_registered_objects(bit_index: int) -> Array:
+	if not _registered_objects.has(bit_index):
+		return []
+	return _registered_objects[bit_index]
 
 ## Called by a registered object to flip its own bit.
 ## Use this when something in the world affects the bit (e.g., bomb destroys obstacle).
 func object_requests_bit_change(bit_index: int, enabled: bool) -> void:
 	set_bit(bit_index, enabled)
 
-## Internal: notify a registered object of its bit state change.
+## Internal: notify all registered objects at a bit index of state change.
 func _notify_registered_object(bit_index: int, enabled: bool) -> void:
-	var object = _registered_objects.get(bit_index)
-	if object and is_instance_valid(object) and object.has_method("on_bit_changed"):
-		object.on_bit_changed(enabled)
+	if not _registered_objects.has(bit_index):
+		return
+	var objects_array: Array = _registered_objects[bit_index]
+	for object in objects_array:
+		if is_instance_valid(object) and object.has_method("on_bit_changed"):
+			object.on_bit_changed(enabled)
 
 ## Internal: auto-cleanup when registered object leaves tree.
-func _on_registered_object_exiting(bit_index: int) -> void:
-	_registered_objects.erase(bit_index)
+func _on_registered_object_exiting(bit_index: int, object: Node) -> void:
+	unregister_object(bit_index, object)
 
 # --- Game Flow ---
 
-func reset_level() -> void:
+func reset_level(reset_checkpoint_progress: bool = false) -> void:
 	bitmask = 0
 	chip_health = chip_max_health
+	if reset_checkpoint_progress:
+		reset_checkpoints()
 
 func reset_game() -> void:
-	reset_level()
+	reset_level(true)
 	current_level = 1
 
 func damage_chip(amount: int = 1) -> void:

--- a/scripts/maskable_behavior.gd
+++ b/scripts/maskable_behavior.gd
@@ -35,7 +35,7 @@ func _ready() -> void:
 		return
 
 	# Store callable for disconnect/reconnect during deactivation
-	_cleanup_callable = GameManager._on_registered_object_exiting.bind(bit_index)
+	_cleanup_callable = GameManager._on_registered_object_exiting.bind(bit_index, self)
 	GameManager.register_object(bit_index, self)
 
 ## Called by GameManager when this bit changes

--- a/scripts/respawn_point.gd
+++ b/scripts/respawn_point.gd
@@ -1,5 +1,7 @@
 class_name RespawnPoint
 extends Marker2D
+## Initial spawn point for the level. This is where the player starts and
+## where they respawn if no checkpoint has been activated.
 
 func _ready() -> void:
-	GameManager.register_respawn_point(self)
+	GameManager.register_respawn_point(self, true)


### PR DESCRIPTION
## Summary

- Add Checkpoint scene that updates respawn point when player touches it
- Update GameManager to track initial spawn vs current checkpoint separately
- Support multiple objects registering to the same bit index

## Related Issue

Closes #6