### PR TITLE
Refactor HUD UI for bitmask boolean operations with submit workflow

### DIFF
--- a/UI/hud_UI.tscn
+++ b/UI/hud_UI.tscn
@@ -2,292 +2,88 @@
 
 [ext_resource type="Script" uid="uid://dc5q35abttbuu" path="res://UI/hud_ui.gd" id="1_is7uo"]
 
-[node name="HudUi" type="Control" unique_id=834537476]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+content_margin_left = 16.0
+content_margin_top = 10.0
+content_margin_right = 16.0
+content_margin_bottom = 10.0
+bg_color = Color(0.05, 0.05, 0.12, 0.85)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0, 0.8, 0.4, 0.5)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxLine" id="StyleBoxLine_sep"]
+color = Color(0, 0.8, 0.4, 0.3)
+thickness = 2
+
+[node name="HudUi" type="Control" unique_id=76213830]
 layout_mode = 3
 anchors_preset = 0
 offset_right = 1152.0
 offset_bottom = 648.0
 script = ExtResource("1_is7uo")
 
-[node name="ColorRect" type="ColorRect" parent="." unique_id=1017114272]
+[node name="Panel" type="PanelContainer" parent="." unique_id=906320381]
 layout_mode = 1
-anchors_preset = -1
-anchor_right = 0.07300001
-anchor_bottom = 0.136
-offset_left = 1054.0
-offset_top = -2.0
-offset_right = 1067.904
-offset_bottom = 7.871994
-grow_horizontal = 0
-color = Color(0, 0, 0, 1)
-
-[node name="ColorRect2" type="ColorRect" parent="." unique_id=987751711]
-layout_mode = 1
-anchors_preset = -1
-anchor_right = 0.07300001
-anchor_bottom = 0.136
-offset_left = 1054.0
-offset_top = 75.0
-offset_right = 1067.904
-offset_bottom = -11.128006
-grow_horizontal = 0
-color = Color(0.89059, 0.89059, 0.8905901, 1)
-
-[node name="Labels" type="GridContainer" parent="." unique_id=1440543874]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.739
-anchor_top = 0.043
-anchor_right = 0.952
-anchor_bottom = 0.21000001
-offset_left = 208.672
-offset_top = -27.864
-offset_right = 55.29602
-offset_bottom = -113.08
-grow_horizontal = 0
-columns = 4
-
-[node name="Label_3" type="RichTextLabel" parent="Labels" unique_id=2146611975]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "A
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Label_2" type="RichTextLabel" parent="Labels" unique_id=1709354704]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "S
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Label_1" type="RichTextLabel" parent="Labels" unique_id=1897227941]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "D
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Label_0" type="RichTextLabel" parent="Labels" unique_id=1086882521]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "F
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="CurrentBits" type="GridContainer" parent="." unique_id=829595734]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.739
-anchor_top = 0.043
-anchor_right = 0.952
-anchor_bottom = 0.21000001
-offset_left = 208.672
-offset_top = -2.8640003
-offset_right = 55.29602
-offset_bottom = -88.08
-grow_horizontal = 0
-columns = 4
-
-[node name="CurrentBit_3" type="RichTextLabel" parent="CurrentBits" unique_id=227894013]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=green]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="CurrentBit_2" type="RichTextLabel" parent="CurrentBits" unique_id=2003964797]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=green]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="CurrentBit_1" type="RichTextLabel" parent="CurrentBits" unique_id=1538120964]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=green]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="CurrentBit_0" type="RichTextLabel" parent="CurrentBits" unique_id=68901664]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=green]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Mask" type="GridContainer" parent="." unique_id=404642368]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.744
-anchor_top = 0.072000004
-anchor_right = 0.952
-anchor_bottom = 0.21000001
-offset_left = 203.08203
-offset_top = 3.343998
-offset_right = 55.466064
-offset_bottom = -63.079987
-grow_horizontal = 0
-columns = 4
-
-[node name="MaskBit_3" type="RichTextLabel" parent="Mask" unique_id=1604468453]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "0
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="MaskBit_2" type="RichTextLabel" parent="Mask" unique_id=2046696481]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "0
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="MaskBit_1" type="RichTextLabel" parent="Mask" unique_id=222470645]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "0
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="MaskBit_0" type="RichTextLabel" parent="Mask" unique_id=1722912226]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "0
-"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Output" type="GridContainer" parent="." unique_id=365802616]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.744
-anchor_top = 0.072000004
-anchor_right = 0.952
-anchor_bottom = 0.21000001
-offset_left = 203.08203
-offset_top = 25.973995
-offset_right = 55.466064
-offset_bottom = -40.44993
-grow_horizontal = 0
-columns = 4
-
-[node name="Output_3" type="RichTextLabel" parent="Output" unique_id=447997963]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=cyan]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Output_2" type="RichTextLabel" parent="Output" unique_id=1395371308]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=cyan]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Output_1" type="RichTextLabel" parent="Output" unique_id=1280334236]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=cyan]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="Output_0" type="RichTextLabel" parent="Output" unique_id=2077818031]
-custom_minimum_size = Vector2(20, 0)
-layout_mode = 2
-size_flags_horizontal = 6
-size_flags_vertical = 6
-bbcode_enabled = true
-text = "[color=cyan]0[/color]"
-fit_content = true
-horizontal_alignment = 1
-
-[node name="AND" type="Button" parent="." unique_id=1346044633]
-custom_minimum_size = Vector2(40, 20)
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.77000004
+anchors_preset = 1
+anchor_left = 1.0
 anchor_right = 1.0
-anchor_bottom = 0.2
-offset_left = 87.95996
-offset_top = 33.0
-offset_right = -122.0
-offset_bottom = -65.600006
+offset_left = -20.0
+offset_top = 12.0
+offset_right = -12.0
 grow_horizontal = 0
-tooltip_text = "Set Masked bits to 0"
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="VBox" type="VBoxContainer" parent="Panel" unique_id=1128346649]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="ButtonRow" type="HBoxContainer" parent="Panel/VBox" unique_id=859688914]
+layout_mode = 2
+theme_override_constants/separation = 8
+alignment = 1
+
+[node name="OR" type="Button" parent="Panel/VBox/ButtonRow" unique_id=1160061567]
+custom_minimum_size = Vector2(60, 28)
+layout_mode = 2
 toggle_mode = true
 button_pressed = true
 action_mode = 0
-text = "AND"
+text = "OR"
 
-[node name="OR" type="Button" parent="." unique_id=1466342298]
-custom_minimum_size = Vector2(40, 20)
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.77000004
-anchor_right = 1.0
-anchor_bottom = 0.2
-offset_left = 30.269958
-offset_top = 33.0
-offset_right = -179.69
-offset_bottom = -65.600006
-grow_horizontal = 0
-tooltip_text = "Set Masked Bits to 1"
+[node name="AND" type="Button" parent="Panel/VBox/ButtonRow" unique_id=992050960]
+custom_minimum_size = Vector2(60, 28)
+layout_mode = 2
 toggle_mode = true
 action_mode = 0
-text = "OR"
+text = "AND"
+
+[node name="Labels" type="GridContainer" parent="Panel/VBox" unique_id=1943957502]
+layout_mode = 2
+theme_override_constants/h_separation = 12
+columns = 4
+
+[node name="CurrentBits" type="GridContainer" parent="Panel/VBox" unique_id=1742154580]
+layout_mode = 2
+theme_override_constants/h_separation = 12
+columns = 4
+
+[node name="Mask" type="GridContainer" parent="Panel/VBox" unique_id=1292766915]
+layout_mode = 2
+theme_override_constants/h_separation = 12
+columns = 4
+
+[node name="Separator" type="HSeparator" parent="Panel/VBox" unique_id=1662532534]
+layout_mode = 2
+theme_override_styles/separator = SubResource("StyleBoxLine_sep")
+
+[node name="Output" type="GridContainer" parent="Panel/VBox" unique_id=1755904268]
+layout_mode = 2
+theme_override_constants/h_separation = 12
+columns = 4

--- a/UI/hud_ui.gd
+++ b/UI/hud_ui.gd
@@ -1,83 +1,340 @@
 extends Control
-@onready var current_bits: GridContainer = $CurrentBits
-@onready var mask: GridContainer = $Mask
-@onready var output: GridContainer = $Output
-@onready var or_button: Button = $OR
-@onready var and_button: Button = $AND
+## HUD UI - Three-row bitmask display with submit workflow.
+##
+## Layout (submit mode):
+##   [OR] [AND]       <- operation selector (Tab to toggle)
+##    A  S  D  F      <- key labels (light up green when bit is on)
+##    0  0  0  1      <- top row: current GameManager bitmask (green)
+##    0  0  0  0      <- middle row: user-toggled mask bits (white)
+##   ────────────     <- separator
+##    0  0  0  1      <- bottom row: real-time preview of operation result (cyan)
+##
+## In submit mode, A/S/D/F toggle local user_mask bits, preview updates live,
+## and Space writes the preview result to GameManager.
+## In realtime mode, A/S/D/F directly toggle GameManager bits (no submit step).
 
-var Or = 0
+# --- Node References ---
+# All UI lives inside Panel > VBox in the scene tree
 
-var maskBit3 = false
-var maskBit2 = false
-var maskBit1 = false
-var maskBit0 = false
+@onready var labels: GridContainer = $Panel/VBox/Labels
+@onready var current_bits: GridContainer = $Panel/VBox/CurrentBits
+@onready var mask: GridContainer = $Panel/VBox/Mask
+@onready var separator: HSeparator = $Panel/VBox/Separator
+@onready var output: GridContainer = $Panel/VBox/Output
+@onready var button_row: HBoxContainer = $Panel/VBox/ButtonRow
+@onready var or_button: Button = $Panel/VBox/ButtonRow/OR
+@onready var and_button: Button = $Panel/VBox/ButtonRow/AND
 
-var outputBit3 = false
-var outputBit2 = false
-var outputBit1 = false
-var outputBit0 = false
+# --- Configuration ---
 
+## When true, A/S/D/F directly toggle GameManager bits (no submit step).
+## When false, uses the three-row preview + Space-to-submit workflow.
+@export var realtime_mode: bool = false
 
-# Called when the node enters the scene tree for the first time.
+# --- Local State (not stored in GameManager) ---
+
+var user_mask: int = 0   ## The middle row bits the player is composing
+var use_or: bool = true  ## true = OR operation, false = AND operation
+
+# --- Input Mapping ---
+# Keys in MSB-first display order: A controls the leftmost (highest) bit,
+# F controls the rightmost (lowest) bit.
+
+var _toggle_keys: Array[int] = [KEY_A, KEY_S, KEY_D, KEY_F]
+
+# --- Display Constants ---
+
+const BIT_FONT_SIZE: int = 22
+const LABEL_FONT_SIZE: int = 16
+const BIT_CELL_MIN_SIZE: Vector2 = Vector2(28, 0)
+const LABEL_CELL_MIN_SIZE: Vector2 = Vector2(28, 0)
+
+# =============================================================================
+# Lifecycle
+# =============================================================================
+
 func _ready() -> void:
-	pass # Replace with function body.
+	GameManager.bitmask_updated.connect(_on_bitmask_updated)
+	GameManager.max_bits_changed.connect(_on_max_bits_changed)
+	# Prevent buttons from capturing keyboard focus (Tab/Space should go to gameplay)
+	or_button.focus_mode = Control.FOCUS_NONE
+	and_button.focus_mode = Control.FOCUS_NONE
+	or_button.pressed.connect(_on_or_pressed)
+	and_button.pressed.connect(_on_and_pressed)
+	_rebuild_ui()
+	_sync_operation_buttons()
+
+# =============================================================================
+# Input
+# =============================================================================
 
 func _unhandled_input(event: InputEvent) -> void:
-	if Input.is_key_pressed(Key.KEY_R):
-		for child in current_bits.get_children():
-			child.text = str(randi()%2)
-			
-	if Input.is_key_pressed(Key.KEY_A):
-		maskBit3 = !maskBit3
-		mask.get_child(0).text = str(int(maskBit3))
-		
-	if Input.is_key_pressed(Key.KEY_S):
-		maskBit2 = !maskBit2
-		mask.get_child(1).text = str(int(maskBit2))
-		
-	if Input.is_key_pressed(Key.KEY_D):
-		maskBit1 = !maskBit1
-		mask.get_child(2).text = str(int(maskBit1))
-		
-	if Input.is_key_pressed(Key.KEY_F):
-		maskBit0 = !maskBit0
-		mask.get_child(3).text = str(int(maskBit0))
-		
-	if Input.is_key_pressed(Key.KEY_SPACE):
-		for child in current_bits.get_children():
-			child.text = output.get_child(child.get_index()).text
-		
-func _update_Output(Toggle: bool) -> void:
-	
-	if Toggle == false:
-			for child in mask.get_children():
-				print(child.text)
-				if child.text == "1":
-					output.get_child(child.get_index()).text = str(0)
-				else:
-					output.get_child(child.get_index()).text = current_bits.get_child(child.get_index()).text
+	if not event is InputEventKey or not event.pressed or event.echo:
+		return
+
+	var max_b: int = GameManager.max_bits
+
+	# --- Bit toggle keys (A/S/D/F) ---
+	# Convert display index i to bit_index: leftmost key = highest bit
+	for i in range(mini(_toggle_keys.size(), max_b)):
+		if event.keycode == _toggle_keys[i]:
+			var bit_index: int = (max_b - 1) - i
+			if realtime_mode:
+				# Directly flip the bit on GameManager (immediate effect)
+				GameManager.toggle_bit(bit_index)
+			else:
+				# Flip the bit on local user_mask (preview only, no game effect yet)
+				user_mask ^= (1 << bit_index)
+				_refresh_middle_row()
+				_refresh_preview_row()
+			return
+
+	# Everything below is submit-mode only
+	if realtime_mode:
+		return
+
+	# --- Tab: toggle between AND / OR ---
+	if event.keycode == KEY_TAB:
+		use_or = not use_or
+		_sync_operation_buttons()
+		_refresh_preview_row()
+		return
+
+	# --- Space: submit preview to GameManager ---
+	if event.keycode == KEY_SPACE:
+		_submit()
+		return
+
+# =============================================================================
+# UI Rebuild — tears down and regenerates all grid cells.
+# Called on startup and whenever max_bits changes (e.g. new level).
+# =============================================================================
+
+func _rebuild_ui() -> void:
+	var max_b: int = GameManager.max_bits
+
+	# Regenerate each grid row with the correct number of cells
+	_rebuild_grid(labels, max_b, _make_label_cell)
+	_rebuild_grid(current_bits, max_b, _make_top_cell)
+	_rebuild_grid(mask, max_b, _make_middle_cell)
+	_rebuild_grid(output, max_b, _make_preview_cell)
+
+	# GridContainer.columns must match the cell count
+	labels.columns = max_b
+	current_bits.columns = max_b
+	mask.columns = max_b
+	output.columns = max_b
+
+	# Reset local state on rebuild
+	user_mask = 0
+
+	# In realtime mode, hide the submit-workflow UI (middle row, preview, buttons)
+	mask.visible = not realtime_mode
+	separator.visible = not realtime_mode
+	output.visible = not realtime_mode
+	button_row.visible = not realtime_mode
+
+	_refresh_all()
+
+## Clear all children from a grid, then populate it using the factory callable.
+func _rebuild_grid(grid: GridContainer, count: int, factory: Callable) -> void:
+	for child in grid.get_children():
+		child.queue_free()
+	for i in range(count):
+		grid.add_child(factory.call(i))
+
+# =============================================================================
+# Cell Factories — create individual RichTextLabel cells for each grid row.
+# display_index is the visual position (0 = leftmost).
+# =============================================================================
+
+## Key hint labels (A, S, D, F) — smaller font, dimmed until active.
+func _make_label_cell(display_index: int) -> RichTextLabel:
+	var label := RichTextLabel.new()
+	label.bbcode_enabled = true
+	label.fit_content = true
+	label.custom_minimum_size = LABEL_CELL_MIN_SIZE
+	label.size_flags_horizontal = Control.SIZE_SHRINK_CENTER | Control.SIZE_EXPAND
+	label.size_flags_vertical = Control.SIZE_SHRINK_CENTER | Control.SIZE_EXPAND
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("normal_font_size", LABEL_FONT_SIZE)
+	var max_b: int = GameManager.max_bits
+	if display_index < _toggle_keys.size() and display_index < max_b:
+		var key_name: String = OS.get_keycode_string(_toggle_keys[display_index])
+		label.text = "[color=#88888888]%s[/color]" % key_name
 	else:
-			for child in mask.get_children():
-				print(child.text)
-				if child.text == "1":
-					output.get_child(child.get_index()).text = str(1)
-					print("ones")
-				else:
-					output.get_child(child.get_index()).text = current_bits.get_child(child.get_index()).text
-	
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	
-	if Input.is_mouse_button_pressed(MouseButton.MOUSE_BUTTON_LEFT):
-		
-		if or_button.is_hovered() == true:
-			and_button.button_pressed = false
-			Or = 1
-			#print("and ", and_button.button_pressed)
-			
-		if and_button.is_hovered() == true:
-			or_button.button_pressed = false
-			Or = 0
-			
-	_update_Output(Or)
-	pass
+		label.text = "[color=#88888888]-[/color]"
+	return label
+
+## Top row cell — shows current GameManager bitmask in green.
+func _make_top_cell(_display_index: int) -> RichTextLabel:
+	var label := _make_bit_cell()
+	label.text = "[color=green]0[/color]"
+	return label
+
+## Middle row cell — shows user_mask bits in white (submit mode only).
+func _make_middle_cell(_display_index: int) -> RichTextLabel:
+	var label := _make_bit_cell()
+	label.text = "0"
+	return label
+
+## Preview row cell — shows computed operation result in cyan.
+func _make_preview_cell(_display_index: int) -> RichTextLabel:
+	var label := _make_bit_cell()
+	label.text = "[color=cyan]0[/color]"
+	return label
+
+## Shared base for all bit-value cells (top, middle, preview rows).
+func _make_bit_cell() -> RichTextLabel:
+	var label := RichTextLabel.new()
+	label.bbcode_enabled = true
+	label.fit_content = true
+	label.custom_minimum_size = BIT_CELL_MIN_SIZE
+	label.size_flags_horizontal = Control.SIZE_SHRINK_CENTER | Control.SIZE_EXPAND
+	label.size_flags_vertical = Control.SIZE_SHRINK_CENTER | Control.SIZE_EXPAND
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("normal_font_size", BIT_FONT_SIZE)
+	return label
+
+# =============================================================================
+# Refresh — update cell text from current state without rebuilding the grid.
+# =============================================================================
+
+func _refresh_all() -> void:
+	_refresh_top_row()
+	_refresh_middle_row()
+	_refresh_preview_row()
+
+## Top row: read GameManager.bitmask and render each bit in green.
+func _refresh_top_row() -> void:
+	var max_b: int = GameManager.max_bits
+	var gm_mask: int = GameManager.bitmask
+	for i in range(current_bits.get_child_count()):
+		var bit_index: int = (max_b - 1) - i
+		var bit_val: int = (gm_mask >> bit_index) & 1
+		current_bits.get_child(i).text = "[color=green]%d[/color]" % bit_val
+
+## Middle row: render user_mask bits as plain 0/1.
+## Also refreshes key labels since they track the same state.
+func _refresh_middle_row() -> void:
+	var max_b: int = GameManager.max_bits
+	for i in range(mask.get_child_count()):
+		var bit_index: int = (max_b - 1) - i
+		var bit_val: int = (user_mask >> bit_index) & 1
+		mask.get_child(i).text = str(bit_val)
+	_refresh_key_labels()
+
+## Key labels: light up green when their corresponding bit is on, dim gray when off.
+## In submit mode, tracks user_mask. In realtime mode, tracks GameManager.bitmask.
+func _refresh_key_labels() -> void:
+	var max_b: int = GameManager.max_bits
+	for i in range(labels.get_child_count()):
+		if i >= _toggle_keys.size() or i >= max_b:
+			break
+		var bit_index: int = (max_b - 1) - i
+		var bit_on: bool
+		if realtime_mode:
+			bit_on = (GameManager.bitmask >> bit_index) & 1 == 1
+		else:
+			bit_on = (user_mask >> bit_index) & 1 == 1
+		var key_name: String = OS.get_keycode_string(_toggle_keys[i])
+		if bit_on:
+			labels.get_child(i).text = "[color=green]%s[/color]" % key_name
+		else:
+			labels.get_child(i).text = "[color=#88888888]%s[/color]" % key_name
+
+## Preview row: render the result of applying the selected operation (AND/OR)
+## between GameManager.bitmask (top) and user_mask (middle) in cyan.
+func _refresh_preview_row() -> void:
+	var max_b: int = GameManager.max_bits
+	var preview: int = _compute_preview()
+	for i in range(output.get_child_count()):
+		var bit_index: int = (max_b - 1) - i
+		var bit_val: int = (preview >> bit_index) & 1
+		output.get_child(i).text = "[color=cyan]%d[/color]" % bit_val
+
+# =============================================================================
+# Boolean Operations
+# =============================================================================
+
+## Compute the result of applying the selected operation between the current
+## GameManager bitmask and the user's local mask.
+func _compute_preview() -> int:
+	if use_or:
+		return GameManager.bitmask | user_mask
+	else:
+		return GameManager.bitmask & user_mask
+
+# =============================================================================
+# Submit — apply the preview result to GameManager and reset local state.
+# This is the only place the HUD writes to GameManager.bitmask.
+# =============================================================================
+
+func _submit() -> void:
+	var preview: int = _compute_preview()
+	GameManager.bitmask = preview  # Triggers bitmask_updated -> all maskable objects react
+	user_mask = 0
+	_refresh_middle_row()
+	_refresh_preview_row()
+
+# =============================================================================
+# Operation Button Styling
+# =============================================================================
+
+## Sync both button states and visuals to match the current use_or value.
+func _sync_operation_buttons() -> void:
+	or_button.button_pressed = use_or
+	and_button.button_pressed = not use_or
+	_style_toggle_button(or_button, use_or)
+	_style_toggle_button(and_button, not use_or)
+
+## Apply green highlight to the active operation button, dim gray to the inactive one.
+## Overrides all button states (normal, pressed, hover) so Godot defaults don't interfere.
+func _style_toggle_button(btn: Button, active: bool) -> void:
+	var style := StyleBoxFlat.new()
+	style.set_corner_radius_all(4)
+	style.set_content_margin_all(4)
+	if active:
+		style.bg_color = Color(0.0, 0.3, 0.15, 0.8)
+		style.border_color = Color(0.0, 0.8, 0.4, 0.6)
+		style.set_border_width_all(1)
+		btn.add_theme_color_override("font_color", Color(0.0, 1.0, 0.4))
+		btn.add_theme_color_override("font_pressed_color", Color(0.0, 1.0, 0.4))
+		btn.add_theme_color_override("font_hover_color", Color(0.0, 1.0, 0.5))
+		btn.add_theme_color_override("font_hover_pressed_color", Color(0.0, 1.0, 0.5))
+	else:
+		style.bg_color = Color(0.1, 0.1, 0.15, 0.5)
+		style.border_color = Color(0.3, 0.3, 0.3, 0.3)
+		style.set_border_width_all(1)
+		btn.add_theme_color_override("font_color", Color(0.4, 0.4, 0.4))
+		btn.add_theme_color_override("font_pressed_color", Color(0.4, 0.4, 0.4))
+		btn.add_theme_color_override("font_hover_color", Color(0.5, 0.5, 0.5))
+		btn.add_theme_color_override("font_hover_pressed_color", Color(0.5, 0.5, 0.5))
+	btn.add_theme_stylebox_override("normal", style)
+	btn.add_theme_stylebox_override("pressed", style)
+	btn.add_theme_stylebox_override("hover", style)
+	btn.add_theme_stylebox_override("hover_pressed", style)
+
+func _on_or_pressed() -> void:
+	use_or = true
+	_sync_operation_buttons()
+	_refresh_preview_row()
+
+func _on_and_pressed() -> void:
+	use_or = false
+	_sync_operation_buttons()
+	_refresh_preview_row()
+
+# =============================================================================
+# Signal Callbacks — respond to external GameManager state changes.
+# =============================================================================
+
+func _on_bitmask_updated(_new_mask: int) -> void:
+	_refresh_top_row()
+	_refresh_preview_row()
+	if realtime_mode:
+		_refresh_key_labels()
+
+## When max_bits changes (e.g. new level loaded), rebuild the entire UI.
+func _on_max_bits_changed(_new_max: int) -> void:
+	_rebuild_ui()

--- a/scenes/Levels/level_01.tscn
+++ b/scenes/Levels/level_01.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource type="TileSet" uid="uid://b4spg8mi60jqv" path="res://art/Images/Tilemaps/test_tiles.tres" id="1_5hi2o"]
 [ext_resource type="PackedScene" uid="uid://cyfopgcmsew45" path="res://scenes/player.tscn" id="2_5hi2o"]
-[ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="3_2nt6v"]
 
 [node name="LevelRoot" type="Node2D" unique_id=1123886121]
 
@@ -13,21 +12,6 @@ tile_set = ExtResource("1_5hi2o")
 
 [node name="Camera2D" type="Camera2D" parent="." unique_id=1152093370]
 position = Vector2(653, 357)
-
-[node name="HudUi" parent="Camera2D" unique_id=834537476 instance=ExtResource("3_2nt6v")]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -576.0
-offset_top = -324.0
-offset_right = 576.0
-offset_bottom = 324.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 2
-size_flags_vertical = 2
 
 [node name="Player" parent="." unique_id=1785403490 instance=ExtResource("2_5hi2o")]
 position = Vector2(155, 542)

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://bxflihtj3hdfj" path="res://scenes/gameplay/game_03.tscn" id="4_g03"]
 [ext_resource type="PackedScene" uid="uid://clpcwb8xlc0b2" path="res://scenes/gameplay/game_04.tscn" id="5_iywne"]
 [ext_resource type="AudioStream" uid="uid://c1lldbd5nb7qb" path="res://sound/20260129_Digital Hell.wav" id="6_p57ef"]
+[ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="7_hud"]
 
 [node name="Game" type="Node" unique_id=1282430220]
 script = ExtResource("1_game")
@@ -15,6 +16,8 @@ level_scenes = Array[PackedScene]([ExtResource("2_g01"), ExtResource("3_g02"), E
 
 [node name="UILayer" type="CanvasLayer" parent="." unique_id=21999873]
 layer = 10
+
+[node name="HudUi" parent="UILayer" instance=ExtResource("7_hud")]
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="." unique_id=572198820]
 stream = ExtResource("6_p57ef")

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -5,7 +5,6 @@
 [ext_resource type="Texture2D" uid="uid://d3f48sis8vt0q" path="res://art/Images/Player/chip_die_01_256x256.png" id="2_tuyoq"]
 [ext_resource type="Texture2D" uid="uid://coa71tkvuabvt" path="res://art/Images/Player/chip_jump_01_256x256.png" id="3_dqkch"]
 [ext_resource type="Texture2D" uid="uid://dtyvne327x3kn" path="res://art/Images/Player/chip_walk_01_256x256.png" id="4_qlg0r"]
-[ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="6_tuyoq"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_a8ls1"]
 atlas = ExtResource("2_tuyoq")
@@ -181,18 +180,3 @@ position = Vector2(-1, 131)
 
 [node name="Camera2D" type="Camera2D" parent="." unique_id=1741698923]
 zoom = Vector2(2, 2)
-
-[node name="HudUi" parent="Camera2D" unique_id=834537476 instance=ExtResource("6_tuyoq")]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -576.0
-offset_top = -324.0
-offset_right = 576.0
-offset_bottom = 324.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 2
-size_flags_vertical = 2

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -146,25 +146,3 @@ func _do_respawn(spawn_position: Vector2) -> void:
 # enemy responds to player death
 func on_player_die() -> void:
 	_do_respawn(enemy_spawn_pos)
-
-# DEBUG ONLY - Remove before release
-# Toggle bits 0-3 with number keys 1-4
-func _input(event: InputEvent) -> void:
-	if !is_player:
-		return
-
-	if event is InputEventKey and event.pressed:
-		match event.keycode:
-			KEY_1:
-				print("DEBUG: Toggling bit 0, current mask: ", GameManager.get_binary_string())
-				GameManager.toggle_bit(0)
-				print("DEBUG: After toggle, mask: ", GameManager.get_binary_string())
-			KEY_2:
-				print("DEBUG: Toggling bit 1")
-				GameManager.toggle_bit(1)
-			KEY_3:
-				print("DEBUG: Toggling bit 2")
-				GameManager.toggle_bit(2)
-			KEY_4:
-				print("DEBUG: Toggling bit 3")
-				GameManager.toggle_bit(3)


### PR DESCRIPTION
## Summary

- Rewrote HUD to integrate with GameManager as single source of truth, with dynamic cell generation based on `max_bits` and three-row display (current bitmask, user mask, preview)
- Implemented AND/OR boolean operations from scratch with Space-to-submit workflow and `@export realtime_mode` toggle for switching between submit and direct manipulation
- Restructured scene with PanelContainer layout in game.tscn UILayer, styled operation buttons with active/inactive states, and removed debug bit-toggle code from player.gd

## Related Issue

Closes #18