### PR TITLE
Implement teleporter object using 2x2 tileset tiles

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -5,12 +5,13 @@
 [ext_resource type="PackedScene" uid="uid://bl0n0th1n7nro" path="res://scenes/gameplay/game_02.tscn" id="3_g02"]
 [ext_resource type="PackedScene" uid="uid://bxflihtj3hdfj" path="res://scenes/gameplay/game_03.tscn" id="4_g03"]
 [ext_resource type="PackedScene" uid="uid://clpcwb8xlc0b2" path="res://scenes/gameplay/game_04.tscn" id="5_iywne"]
-[ext_resource type="AudioStream" uid="uid://c1lldbd5nb7qb" path="res://sound/20260129_Digital Hell.wav" id="6_p57ef"]
+[ext_resource type="PackedScene" uid="uid://j81nawgx55c6" path="res://scenes/gameplay/game_05.tscn" id="6_g05"]
+[ext_resource type="AudioStream" uid="uid://c1lldbd5nb7qb" path="res://sound/20260129_Digital Hell.wav" id="7_p57ef"]
 [ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="7_hud"]
 
 [node name="Game" type="Node" unique_id=1282430220]
 script = ExtResource("1_game")
-level_scenes = Array[PackedScene]([ExtResource("2_g01"), ExtResource("3_g02"), ExtResource("4_g03"), ExtResource("5_iywne")])
+level_scenes = Array[PackedScene]([ExtResource("2_g01"), ExtResource("3_g02"), ExtResource("4_g03"), ExtResource("5_iywne"), ExtResource("6_g05")])
 
 [node name="LevelSlot" type="Node" parent="." unique_id=337242142]
 
@@ -20,5 +21,5 @@ layer = 10
 [node name="HudUi" parent="UILayer" instance=ExtResource("7_hud")]
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="." unique_id=572198820]
-stream = ExtResource("6_p57ef")
+stream = ExtResource("7_p57ef")
 autoplay = true

--- a/scenes/gameplay/game_05.tscn
+++ b/scenes/gameplay/game_05.tscn
@@ -1,0 +1,86 @@
+[gd_scene format=4 uid="uid://j81nawgx55c6"]
+
+[ext_resource type="Script" uid="uid://cep63iec2pfso" path="res://scripts/level_config.gd" id="1_r6ev0"]
+[ext_resource type="Texture2D" uid="uid://b8fd6qd0g07mb" path="res://art/Images/Backgrounds/bg_03_gradient.png" id="2_372ti"]
+[ext_resource type="TileSet" uid="uid://dptm01tileset" path="res://art/Images/Tilemaps/tilemap_01.tres" id="3_72etx"]
+[ext_resource type="Script" uid="uid://bkync7mhgcj7x" path="res://scripts/maskable_tilemap.gd" id="4_4bgl1"]
+[ext_resource type="Script" uid="uid://cav56ej2travj" path="res://scripts/maskable_behavior.gd" id="5_hupe7"]
+[ext_resource type="PackedScene" uid="uid://cyfopgcmsew45" path="res://scenes/player.tscn" id="6_jxwa5"]
+[ext_resource type="PackedScene" uid="uid://cxrgcw8hybmme" path="res://scenes/teleporter.tscn" id="7_telep"]
+
+[node name="game_01" type="Node2D" unique_id=2096551147]
+
+[node name="level_config" type="Node" parent="." unique_id=885048635]
+script = ExtResource("1_r6ev0")
+bit_0 = true
+bit_1 = true
+bit_2 = true
+
+[node name="BackgroundLayer" type="Parallax2D" parent="." unique_id=83914724]
+scroll_scale = Vector2(0.1, 0.1)
+
+[node name="BackgroundImage" type="Sprite2D" parent="BackgroundLayer" unique_id=1749065152]
+position = Vector2(656, 313)
+scale = Vector2(0.49072263, 0.42480466)
+texture = ExtResource("2_372ti")
+
+[node name="tilemap_always" type="TileMapLayer" parent="." unique_id=298539414]
+tile_map_data = PackedByteArray("AAATABQAAAAJAAkAAAASABcAAAAJAAkAAAATABcAAAAJAAkAAAAUABcAAAAJAAkAAAARABcAAAAJAAkAAAA=")
+tile_set = ExtResource("3_72etx")
+script = ExtResource("4_4bgl1")
+
+[node name="tilemap_0" type="TileMapLayer" parent="." unique_id=840074273]
+tile_map_data = PackedByteArray("AAABABcAAAAKAAUAAAACABcAAAAKAAUAAAADABcAAAAKAAUAAAAEABcAAAAKAAUAAAAFABcAAAAKAAUAAAAGABcAAAAKAAUAAAAHABcAAAAKAAUAAAAIABcAAAALAAUAAAAMABcAAAAJAAUAAAANABcAAAAKAAUAAAAOABcAAAAKAAUAAAAPABcAAAAKAAUAAAAQABcAAAAKAAUAAAARABcAAAAKAAUAAAASABcAAAAKAAUAAAATABcAAAAKAAUAAAAUABcAAAALAAUAAAAAABcAAAAKAAUAAAD//xcAAAAKAAUAAAD+/xcAAAAKAAUAAAD9/xcAAAAKAAUAAAD8/xcAAAAKAAUAAAD7/xcAAAAKAAUAAAD6/xcAAAAKAAUAAAD5/xcAAAAKAAUAAAD4/xcAAAAJAAUAAAA=")
+tile_set = ExtResource("3_72etx")
+script = ExtResource("4_4bgl1")
+
+[node name="MaskableBehavior" type="Node" parent="tilemap_0" unique_id=1886600958]
+script = ExtResource("5_hupe7")
+
+[node name="tilemap_1" type="TileMapLayer" parent="." unique_id=754066882]
+tile_map_data = PackedByteArray("AAAJABcAAAAPAAYAAAAKABcAAAAPAAYAAAALABcAAAAPAAYAAAAJABQAAAAPAAUAAAAJABUAAAAPAAYAAAAJABYAAAAPAAYAAAAKABQAAAAPAAUAAAAKABUAAAAPAAYAAAAKABYAAAAPAAYAAAALABQAAAAPAAUAAAALABUAAAAPAAYAAAALABYAAAAPAAYAAAA=")
+tile_set = ExtResource("3_72etx")
+script = ExtResource("4_4bgl1")
+
+[node name="MaskableBehavior" type="Node" parent="tilemap_1" unique_id=480062592]
+script = ExtResource("5_hupe7")
+bit_index = 2
+
+[node name="tilemap_2" type="TileMapLayer" parent="." unique_id=43596102]
+position = Vector2(-2, 0)
+tile_set = ExtResource("3_72etx")
+script = ExtResource("4_4bgl1")
+
+[node name="MaskableBehavior" type="Node" parent="tilemap_2" unique_id=998158842]
+script = ExtResource("5_hupe7")
+bit_index = 2
+
+[node name="tilemap_3" type="TileMapLayer" parent="." unique_id=1708417475]
+position = Vector2(-2, 0)
+tile_set = ExtResource("3_72etx")
+script = ExtResource("4_4bgl1")
+
+[node name="MaskableBehavior" type="Node" parent="tilemap_3" unique_id=806094233]
+script = ExtResource("5_hupe7")
+bit_index = 3
+
+[node name="Player" parent="." unique_id=1785403490 instance=ExtResource("6_jxwa5")]
+position = Vector2(-98, 323)
+scale = Vector2(0.25, 0.25)
+
+[node name="TeleporterA" parent="." unique_id=877404520 instance=ExtResource("7_telep")]
+position = Vector2(110, 333)
+paired_teleporter = NodePath("../TeleporterB")
+
+[node name="MaskableBehavior" parent="TeleporterA" index="0" unique_id=1414619879]
+bit_index = 1
+
+[node name="TeleporterB" parent="." unique_id=277601434 instance=ExtResource("7_telep")]
+position = Vector2(234, 335)
+paired_teleporter = NodePath("../TeleporterA")
+
+[node name="MaskableBehavior" parent="TeleporterB" index="0" unique_id=1414619879]
+bit_index = 1
+
+[editable path="TeleporterA"]
+[editable path="TeleporterB"]

--- a/scenes/teleporter.tscn
+++ b/scenes/teleporter.tscn
@@ -1,0 +1,24 @@
+[gd_scene format=3 uid="uid://cxrgcw8hybmme"]
+
+[ext_resource type="Script" uid="uid://dfjw16li2n226" path="res://scripts/teleporter.gd" id="1_teleporter"]
+[ext_resource type="Script" uid="uid://cav56ej2travj" path="res://scripts/maskable_behavior.gd" id="2_maskable"]
+[ext_resource type="Texture2D" uid="uid://on1bh30mvk1m" path="res://art/Images/Tilemaps/tilemap_01.png" id="3_hkm18"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_1"]
+size = Vector2(32, 32)
+
+[node name="Teleporter" type="Area2D" unique_id=124518824]
+collision_layer = 0
+script = ExtResource("1_teleporter")
+
+[node name="MaskableBehavior" type="Node" parent="." unique_id=1414619879]
+script = ExtResource("2_maskable")
+
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=1975173773]
+scale = Vector2(2, 2)
+texture = ExtResource("3_hkm18")
+region_enabled = true
+region_rect = Rect2(288, 80, 32, 32)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=934271959]
+shape = SubResource("RectangleShape2D_1")

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -144,6 +144,15 @@ func _do_respawn(spawn_position: Vector2) -> void:
 	else:
 		parent.add_child(self)
 
+## Instantly moves Chip to the given position. Called by Teleporter.
+## Resets velocity so momentum from before the teleport doesn't carry over
+## (otherwise Chip would keep moving at whatever speed he had before).
+func teleport(destination: Vector2) -> void:
+	if _is_dead:
+		return
+	global_position = destination
+	velocity = Vector2.ZERO
+
 # enemy responds to player death
 func on_player_die() -> void:
 	_do_respawn(enemy_spawn_pos)

--- a/scripts/teleporter.gd
+++ b/scripts/teleporter.gd
@@ -1,0 +1,160 @@
+class_name Teleporter
+extends Area2D
+## Paired teleporter that transports Chip from entry to exit on contact.
+## Place two Teleporter instances in a level and link them to each other
+## via the paired_teleporter export in the Inspector.
+##
+## Supports MaskableBehavior for bitmask toggling (show/hide + enable/disable).
+##
+## Any body that should be teleportable must implement:
+##   teleport(destination: Vector2) -> void
+## Currently only the Player implements this. The NPC does not, so it
+## will walk through teleporters without being affected.
+
+## Path to the other teleporter this one sends bodies to. Set in the Inspector.
+@export var paired_teleporter: NodePath
+
+## How long (in seconds) the exit teleporter ignores collisions after receiving
+## a body. This prevents the classic "infinite teleport loop" where arriving at
+## the exit immediately triggers it to send you back.
+@export var cooldown_duration: float = 0.5
+
+## Reference to the Sprite2D child node, used for the flash visual effect.
+## @onready means this is set automatically when the node enters the scene tree.
+@onready var sprite: Sprite2D = $Sprite2D
+
+## How fast the sprite rotates, in radians per second.
+## PI means a full 180° turn per second (a full spin takes 2 seconds).
+@export var spin_speed: float = PI * 0.25
+
+## How fast the scale pulses (higher = faster breathing).
+@export var pulse_speed: float = 3.0
+
+## How much the scale grows/shrinks from its base size.
+## 0.1 means it oscillates between 90% and 110% of its normal scale.
+@export var pulse_amount: float = 0.04
+
+## When true, this teleporter won't activate. Used to prevent infinite loops:
+## the exit teleporter is put on cooldown right before the body arrives.
+var _is_on_cooldown: bool = false
+
+## Tracks total elapsed time for the pulse animation.
+## We feed this into sin() to get a smooth oscillation.
+var _time: float = 0.0
+
+## The sprite's original scale from the scene, captured at startup.
+## The pulse animation multiplies this so it always works relative to
+## whatever scale you set in the Inspector.
+var _base_sprite_scale: Vector2
+
+func _ready() -> void:
+	# Area2D emits body_entered when a physics body overlaps our CollisionShape2D.
+	# We connect that signal to our handler so we know when something steps in.
+	body_entered.connect(_on_body_entered)
+
+	# Capture the sprite's scale as set in the scene so the pulse animation
+	# can use it as a baseline. Change the scale in the Inspector and the
+	# animation will automatically adapt — no hardcoded values needed.
+	if sprite:
+		_base_sprite_scale = sprite.scale
+
+func _process(delta: float) -> void:
+	if sprite == null:
+		return
+
+	# Accumulate time so our animations progress smoothly each frame
+	_time += delta
+
+	# Rotate the sprite continuously. delta ensures consistent speed
+	# regardless of frame rate (e.g. at 60fps, delta ≈ 0.016 seconds).
+	sprite.rotation += spin_speed * delta
+
+	# Pulse the scale using sin() for a smooth "breathing" effect.
+	# sin() outputs -1 to 1, so we multiply by pulse_amount to get
+	# a small oscillation (e.g. 0.9 to 1.1 with pulse_amount = 0.1).
+	# We use the sprite's base scale (set in the scene) as the center point.
+	var pulse: float = 1.0 + sin(_time * pulse_speed) * pulse_amount
+	sprite.scale = _base_sprite_scale * pulse
+
+func _on_body_entered(body: Node2D) -> void:
+	# --- Guard checks: bail out early if we shouldn't teleport ---
+
+	# This teleporter is on cooldown (something just arrived here)
+	if _is_on_cooldown:
+		return
+
+	# The body doesn't have a teleport() method, so it's not teleportable
+	# (e.g. the NPC, or any other physics body that wanders in)
+	if not body.has_method("teleport"):
+		return
+
+	# Look up the paired teleporter. If it's missing or invalid, do nothing.
+	var target := _get_paired_teleporter()
+	if target == null:
+		return
+
+	# The exit teleporter has been disabled via bitmask — don't send Chip
+	# to a teleporter that's turned off. "monitoring" is the Area2D property
+	# that controls whether it detects collisions; we also use it as our
+	# "is this teleporter active?" flag in on_bit_changed().
+	if not target.monitoring:
+		return
+
+	# --- All checks passed, do the teleport ---
+
+	# IMPORTANT: Set cooldown on the EXIT teleporter BEFORE moving the body.
+	# When we move Chip to the exit's position, Godot will fire body_entered
+	# on the exit teleporter. The cooldown flag makes that second trigger
+	# get ignored, preventing an infinite A→B→A→B loop.
+	target._is_on_cooldown = true
+
+	# Ask the body to teleport itself (the Player handles its own position
+	# and velocity reset inside its teleport() method)
+	body.teleport(target.global_position)
+
+	# Visual feedback: flash both teleporters so the player sees what happened
+	_flash()
+	target._flash()
+
+	# Start a timer to re-enable the exit teleporter after the cooldown.
+	# This allows bidirectional teleportation — once the cooldown expires,
+	# Chip can step into the exit to go back.
+	target._start_cooldown_timer()
+
+## Looks up the paired teleporter node from the exported NodePath.
+## Returns null if the path is empty or the node no longer exists.
+func _get_paired_teleporter() -> Teleporter:
+	if paired_teleporter.is_empty():
+		return null
+	# get_node_or_null returns null instead of crashing if the path is invalid
+	var node = get_node_or_null(paired_teleporter)
+	if not is_instance_valid(node):
+		return null
+	return node as Teleporter
+
+## Waits for cooldown_duration seconds, then re-arms this teleporter.
+## Uses Godot's built-in SceneTree timer — "await" pauses this function
+## until the timer fires, then execution resumes on the next line.
+func _start_cooldown_timer() -> void:
+	await get_tree().create_timer(cooldown_duration).timeout
+	_is_on_cooldown = false
+
+## Plays a brief cyan flash on the sprite to indicate teleporter activation.
+## Uses a Tween to animate the "modulate" property (a color multiplier that
+## tints the entire sprite). Fades to cyan, then back to white (normal).
+func _flash() -> void:
+	if sprite == null:
+		return
+	var tween = create_tween()
+	tween.tween_property(sprite, "modulate", Color(0.3, 1.0, 1.0, 1.0), 0.1)
+	tween.tween_property(sprite, "modulate", Color.WHITE, 0.15)
+
+## Called by MaskableBehavior when this teleporter's bit is toggled.
+## Shows/hides the teleporter and enables/disables its collision detection.
+## "monitoring" controls whether the Area2D detects bodies entering it.
+func on_bit_changed(enabled: bool) -> void:
+	visible = enabled
+	monitoring = enabled
+	# Reset cooldown when re-enabled so the teleporter is immediately usable
+	if enabled:
+		_is_on_cooldown = false


### PR DESCRIPTION
## Summary

- Add paired teleporter system (entry/exit) with cooldown-based infinite loop prevention
- Teleporters integrate with MaskableBehavior for bitmask toggling, include spin/pulse idle animations and cyan flash feedback on teleport
- Player gains `teleport(destination)` method so teleporter doesn't reach into player internals
- Teleporter pair placed in new game_05 level and wired into level sequence

## Related Issue

Closes #20