### PR TITLE
feat: add greyscale tile swapping for disabled tilemap layers

### DIFF
--- a/scripts/maskable_tilemap.gd
+++ b/scripts/maskable_tilemap.gd
@@ -6,16 +6,52 @@ extends TileMapLayer
 ## 1. Auto-registers with GameManager so player can check tile data (is_deadly, jump_force)
 ## 2. Implements on_bit_changed() so it can be toggled via MaskableBehavior
 ##
+## When toggled off, swaps all tiles from the normal atlas source to a greyscale
+## atlas source so the player can still see where disabled tiles are. Collision
+## is also disabled so the player passes through.
+##
 ## Usage:
-##   - Just attach this script to a TileMapLayer
+##   - Attach this script to a TileMapLayer
 ##   - Add a MaskableBehavior child if you want it toggleable via bitmask
+##   - In your TileSet, add the greyscale atlas as a second source
+##   - Set source_normal and source_greyscale in the Inspector to match
+##     the source IDs shown in the TileSet editor
+
+## The source ID in the TileSet for normal (colored) tiles.
+@export var source_normal: int = 0
+
+## The source ID in the TileSet for greyscale (disabled) tiles.
+## Set to -1 to disable greyscale swapping (falls back to hiding the layer).
+@export var source_greyscale: int = -1
+
+## Whether the greyscale source exists in the TileSet.
+## Checked once at startup so we don't query every bit change.
+var _has_greyscale: bool = false
 
 func _ready() -> void:
 	GameManager.register_tilemap(self)
+	# Check if the greyscale atlas source actually exists in the TileSet.
+	# If not, we fall back to the old show/hide behavior until it's added.
+	if source_greyscale >= 0 and tile_set and tile_set.has_source(source_greyscale):
+		_has_greyscale = true
 
 func _exit_tree() -> void:
 	GameManager.unregister_tilemap(self)
 
-## Called by MaskableBehavior when this tilemap's bit changes
+## Called by MaskableBehavior when this tilemap's bit changes.
+## If a greyscale atlas source is configured, swaps tiles between normal and
+## greyscale. Otherwise falls back to simply hiding the layer.
 func on_bit_changed(bit_enabled: bool) -> void:
-	enabled = bit_enabled
+	collision_enabled = bit_enabled
+
+	if _has_greyscale:
+		# Swap tiles between normal and greyscale atlas sources.
+		# The layer stays visible so the player can see disabled tiles.
+		var target_source = source_normal if bit_enabled else source_greyscale
+		for coords in get_used_cells():
+			var atlas_coords = get_cell_atlas_coords(coords)
+			var alt = get_cell_alternative_tile(coords)
+			set_cell(coords, target_source, atlas_coords, alt)
+	else:
+		# No greyscale source yet — just hide/show the whole layer
+		visible = bit_enabled


### PR DESCRIPTION
## Summary
- Tilemap layers now swap tiles to a greyscale atlas source when toggled off via bitmask, so players can see where disabled tiles are
- Falls back to old show/hide behavior if no greyscale source is configured (`source_greyscale = -1` by default)
- Updated both `maskable_tilemap.gd` and `hazard_tilemap.gd` with the same pattern

## Setup (once Mike's greyscale atlas is ready)
1. Add the greyscale atlas image as a new source in the TileSet
2. Set `source_greyscale` in the Inspector on each maskable tilemap to match the new source ID

## Test plan
- [ ] Verify existing levels still work with default settings (greyscale disabled, falls back to hide/show)
- [ ] Once greyscale atlas is added, verify tiles swap to greyscale when bit is toggled off
- [ ] Verify tiles swap back to normal when bit is toggled on
- [ ] Verify collision is disabled on greyscale tiles (player passes through)
- [ ] Verify hazard Area2Ds stop killing player when hazard tilemap is toggled off