### PR TITLE
feat: bit color overlay system for tilemap identification

### DIFF
--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -12,6 +12,34 @@ signal level_completed
 signal max_bits_changed(new_max: int)
 signal checkpoint_activated(checkpoint: Vector2)
 
+# --- Bit Colors ---
+## Color assigned to each bit index, used for visual feedback (outlines, HUD, etc.).
+## Intentionally bright/saturated so they stand out against greyscale tiles.
+const BIT_COLORS: Array[Color] = [
+	Color(1.0, 0.2, 0.2),   # 0: Red
+	Color(0.3, 0.5, 1.0),   # 1: Blue
+	Color(0.7, 0.2, 1.0),   # 2: Violet
+	Color(1.0, 0.9, 0.2),   # 3: Yellow
+	Color(1.0, 0.3, 0.8),   # 4: Magenta
+	Color(0.3, 1.0, 1.0),   # 5: Cyan
+	Color(1.0, 0.6, 0.1),   # 6: Orange
+	Color(0.7, 0.3, 1.0),   # 7: Purple
+	Color(1.0, 0.5, 0.5),   # 8: Light Red
+	Color(0.5, 0.7, 1.0),   # 9: Light Blue
+	Color(0.8, 0.5, 1.0),   # 10: Light Violet
+	Color(1.0, 1.0, 0.5),   # 11: Light Yellow
+	Color(1.0, 0.6, 0.9),   # 12: Light Magenta
+	Color(0.6, 1.0, 1.0),   # 13: Light Cyan
+	Color(1.0, 0.8, 0.5),   # 14: Light Orange
+	Color(0.8, 0.6, 1.0),   # 15: Light Purple
+]
+
+## Get the color for a given bit index. Returns white if out of range.
+static func get_bit_color(bit_index: int) -> Color:
+	if bit_index >= 0 and bit_index < BIT_COLORS.size():
+		return BIT_COLORS[bit_index]
+	return Color.WHITE
+
 # --- Bitmask State ---
 ## The current bitmask controlling level objects.
 ## Each bit (0-7 for 8-bit, 0-15 for 16-bit, etc.) maps to a maskable object.

--- a/scripts/hazard_tilemap.gd
+++ b/scripts/hazard_tilemap.gd
@@ -2,35 +2,77 @@ class_name hazard_tilemap
 extends TileMapLayer
 
 ## TileMapLayer that auto-generates Area2D hazard zones for tiles with is_deadly custom data.
-## Attach this script to a TileMapLayer instead of maskable_tilemap.gd,
-## or use it alongside by keeping both scripts on separate layers.
+## Also creates a colored overlay (based on bit index) so the player can always
+## see which bit controls this tilemap.
 ##
-## When toggled off, swaps tiles to greyscale and disables hazard Area2Ds
-## so the player can see where hazards are without being killed by them.
+## When toggled off via bitmask:
+##   - Disables hazard Area2Ds so they stop killing the player
+##   - Dims tiles via self_modulate
+##   - If a greyscale atlas source is configured, also swaps tiles to greyscale art
 
 ## The source ID in the TileSet for normal (colored) tiles.
 @export var source_normal: int = 0
 
 ## The source ID in the TileSet for greyscale (disabled) tiles.
-## Set to -1 to disable greyscale swapping (falls back to hiding the layer).
+## Set to -1 to disable greyscale swapping (modulate dimming is used instead).
 @export var source_greyscale: int = -1
 
 ## Whether the greyscale source exists in the TileSet.
 ## Checked once at startup so we don't query every bit change.
 var _has_greyscale: bool = false
 
+## Which bit controls this tilemap. Discovered from MaskableBehavior child at startup.
+var _bit_index: int = -1
+
+## Container node holding per-tile ColorRect overlays, tinted with this bit's
+## color so the player can always see which bit controls this tilemap.
+var _color_overlay: Node2D = null
+
 func _ready() -> void:
 	# Disable tile physics — hazard detection uses generated Area2Ds instead
 	collision_enabled = false
 	GameManager.register_tilemap(self)
 	_generate_hazard_areas()
+
 	# Check if the greyscale atlas source actually exists in the TileSet.
-	# If not, we fall back to the old show/hide behavior until it's added.
 	if source_greyscale >= 0 and tile_set and tile_set.has_source(source_greyscale):
 		_has_greyscale = true
 
+	# Find our bit_index from MaskableBehavior child so we can look up our color.
+	for child in get_children():
+		if child is MaskableBehavior:
+			_bit_index = child.bit_index
+			break
+
+	_create_color_overlay()
+
 func _exit_tree() -> void:
 	GameManager.unregister_tilemap(self)
+
+## Create a per-tile ColorRect overlay for each used cell, grouped under a
+## single Node2D container. One rect per tile avoids covering empty space
+## between scattered tiles.
+func _create_color_overlay() -> void:
+	var used_cells := get_used_cells()
+	if used_cells.is_empty():
+		return
+
+	var tile_size := Vector2(tile_set.tile_size)
+	var half := tile_size / 2.0
+	var bit_color := GameManager.get_bit_color(_bit_index)
+	var overlay_color := Color(bit_color.r, bit_color.g, bit_color.b, 0.25)
+
+	_color_overlay = Node2D.new()
+	add_child(_color_overlay)
+
+	for cell in used_cells:
+		var center := map_to_local(cell)
+		var rect := ColorRect.new()
+		rect.position = center - half
+		rect.size = tile_size
+		rect.color = overlay_color
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_color_overlay.add_child(rect)
 
 func on_bit_changed(bit_enabled: bool) -> void:
 	# Toggle hazard Area2Ds so disabled hazards don't kill the player
@@ -38,17 +80,21 @@ func on_bit_changed(bit_enabled: bool) -> void:
 		if child is Area2D:
 			child.monitoring = bit_enabled
 
-	if _has_greyscale:
-		# Swap tiles between normal and greyscale.
-		# The tilemap stays visible either way so the player can see where hazards are.
-		var target_source = source_normal if bit_enabled else source_greyscale
-		for coords in get_used_cells():
-			var atlas_coords = get_cell_atlas_coords(coords)
-			var alt = get_cell_alternative_tile(coords)
-			set_cell(coords, target_source, atlas_coords, alt)
+	if bit_enabled:
+		self_modulate = Color.WHITE
+		if _has_greyscale:
+			_swap_tiles(source_normal)
 	else:
-		# No greyscale source yet — just hide/show the whole layer
-		visible = bit_enabled
+		self_modulate = Color(0.5, 0.5, 0.5, 0.4)
+		if _has_greyscale:
+			_swap_tiles(source_greyscale)
+
+## Swap all tiles to a different atlas source, preserving position and alternatives.
+func _swap_tiles(target_source: int) -> void:
+	for coords in get_used_cells():
+		var atlas_coords = get_cell_atlas_coords(coords)
+		var alt = get_cell_alternative_tile(coords)
+		set_cell(coords, target_source, atlas_coords, alt)
 
 func _generate_hazard_areas() -> void:
 	var used_cells := get_used_cells()

--- a/scripts/maskable_tilemap.gd
+++ b/scripts/maskable_tilemap.gd
@@ -2,56 +2,102 @@ class_name gameplay_tilemap
 extends TileMapLayer
 ## Attach to any TileMapLayer that has gameplay-relevant tiles.
 ##
-## This script does two things:
+## This script does three things:
 ## 1. Auto-registers with GameManager so player can check tile data (is_deadly, jump_force)
 ## 2. Implements on_bit_changed() so it can be toggled via MaskableBehavior
+## 3. Creates a colored overlay (based on bit index) so the player can always
+##    see which bit controls this tilemap
 ##
-## When toggled off, swaps all tiles from the normal atlas source to a greyscale
-## atlas source so the player can still see where disabled tiles are. Collision
-## is also disabled so the player passes through.
+## When toggled off via bitmask:
+##   - Disables collision so the player passes through
+##   - Dims tiles via self_modulate
+##   - If a greyscale atlas source is configured, also swaps tiles to greyscale art
 ##
 ## Usage:
 ##   - Attach this script to a TileMapLayer
 ##   - Add a MaskableBehavior child if you want it toggleable via bitmask
-##   - In your TileSet, add the greyscale atlas as a second source
-##   - Set source_normal and source_greyscale in the Inspector to match
-##     the source IDs shown in the TileSet editor
+##   - (Optional) In your TileSet, add a greyscale atlas as a second source
+##     and set source_greyscale in the Inspector to match its source ID
 
 ## The source ID in the TileSet for normal (colored) tiles.
 @export var source_normal: int = 0
 
 ## The source ID in the TileSet for greyscale (disabled) tiles.
-## Set to -1 to disable greyscale swapping (falls back to hiding the layer).
+## Set to -1 to disable greyscale swapping (modulate dimming is used instead).
 @export var source_greyscale: int = -1
 
 ## Whether the greyscale source exists in the TileSet.
 ## Checked once at startup so we don't query every bit change.
 var _has_greyscale: bool = false
 
+## Which bit controls this tilemap. Discovered from MaskableBehavior child at startup.
+var _bit_index: int = -1
+
+## Container node holding per-tile ColorRect overlays, tinted with this bit's
+## color so the player can always see which bit controls this tilemap.
+## Always visible — the only difference between enabled/disabled is self_modulate
+## dimming and greyscale tile swapping.
+var _color_overlay: Node2D = null
+
 func _ready() -> void:
 	GameManager.register_tilemap(self)
+
 	# Check if the greyscale atlas source actually exists in the TileSet.
-	# If not, we fall back to the old show/hide behavior until it's added.
 	if source_greyscale >= 0 and tile_set and tile_set.has_source(source_greyscale):
 		_has_greyscale = true
+
+	# Find our bit_index from MaskableBehavior child so we can look up our color.
+	for child in get_children():
+		if child is MaskableBehavior:
+			_bit_index = child.bit_index
+			break
+
+	_create_color_overlay()
 
 func _exit_tree() -> void:
 	GameManager.unregister_tilemap(self)
 
+## Create a per-tile ColorRect overlay for each used cell, grouped under a
+## single Node2D container. One rect per tile avoids covering empty space
+## between scattered tiles.
+func _create_color_overlay() -> void:
+	var used_cells := get_used_cells()
+	if used_cells.is_empty():
+		return
+
+	var tile_size := Vector2(tile_set.tile_size)
+	var half := tile_size / 2.0
+	var bit_color := GameManager.get_bit_color(_bit_index)
+	var overlay_color := Color(bit_color.r, bit_color.g, bit_color.b, 0.25)
+
+	_color_overlay = Node2D.new()
+	add_child(_color_overlay)
+
+	for cell in used_cells:
+		var center := map_to_local(cell)
+		var rect := ColorRect.new()
+		rect.position = center - half
+		rect.size = tile_size
+		rect.color = overlay_color
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_color_overlay.add_child(rect)
+
 ## Called by MaskableBehavior when this tilemap's bit changes.
-## If a greyscale atlas source is configured, swaps tiles between normal and
-## greyscale. Otherwise falls back to simply hiding the layer.
 func on_bit_changed(bit_enabled: bool) -> void:
 	collision_enabled = bit_enabled
 
-	if _has_greyscale:
-		# Swap tiles between normal and greyscale atlas sources.
-		# The layer stays visible so the player can see disabled tiles.
-		var target_source = source_normal if bit_enabled else source_greyscale
-		for coords in get_used_cells():
-			var atlas_coords = get_cell_atlas_coords(coords)
-			var alt = get_cell_alternative_tile(coords)
-			set_cell(coords, target_source, atlas_coords, alt)
+	if bit_enabled:
+		self_modulate = Color.WHITE
+		if _has_greyscale:
+			_swap_tiles(source_normal)
 	else:
-		# No greyscale source yet — just hide/show the whole layer
-		visible = bit_enabled
+		self_modulate = Color(0.5, 0.5, 0.5, 0.4)
+		if _has_greyscale:
+			_swap_tiles(source_greyscale)
+
+## Swap all tiles to a different atlas source, preserving position and alternatives.
+func _swap_tiles(target_source: int) -> void:
+	for coords in get_used_cells():
+		var atlas_coords = get_cell_atlas_coords(coords)
+		var alt = get_cell_alternative_tile(coords)
+		set_cell(coords, target_source, atlas_coords, alt)


### PR DESCRIPTION
## Summary
- Add `BIT_COLORS` array (16 colors, no greens) and `get_bit_color()` helper to GameManager
- Tilemap layers now create per-tile ColorRect overlays at startup, tinted with their bit's color so players can always identify which bit controls which tiles
- When disabled: tiles are dimmed via `self_modulate`, greyscale atlas swap still works when configured
- HUD key labels (A/S/D/F) always show their saturated bit color; bitmask row always uses bit colors; mask/preview rows use bit color for 1s

## Test plan
- [ ] Run the game — all tilemap layers should show a subtle color tint matching their bit
- [ ] Toggle bits — disabled tiles should dim but keep the color overlay visible
- [ ] Check HUD colors match the tilemap overlays (F=red, D=blue, S=violet, A=yellow)
- [ ] Verify no green colors appear in bit assignments (conflicts with game palette)
- [ ] Verify scattered tilemaps (e.g. level 3, D bit) don't have oversized overlays