### PR TITLE
Add end screen taunt audio and start menu quit option

### DIFF
--- a/UI/end_screen.gd
+++ b/UI/end_screen.gd
@@ -6,6 +6,7 @@ extends Control
 signal menu_requested
 
 @onready var prompt_label: RichTextLabel = $Content/PromptLabel
+@onready var taunt_player: AudioStreamPlayer = $TauntPlayer
 
 var _tween: Tween
 
@@ -24,9 +25,11 @@ func _unhandled_input(event: InputEvent) -> void:
 func show_screen() -> void:
 	visible = true
 	_start_pulse()
+	taunt_player.play()
 
 func hide_screen() -> void:
 	visible = false
+	taunt_player.stop()
 	if _tween:
 		_tween.kill()
 		_tween = null

--- a/UI/end_screen.tscn
+++ b/UI/end_screen.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" path="res://UI/end_screen.gd" id="1_script"]
 [ext_resource type="FontFile" uid="uid://be85l0hqahuhe" path="res://UI/Fonts/ChicagoFLF.ttf" id="2_font"]
+[ext_resource type="AudioStream" path="res://sound/20260131_DAEMON's Taunt.wav" id="3_taunt"]
 
 [node name="EndScreen" type="Control"]
 layout_mode = 3
@@ -49,3 +50,6 @@ fit_content = true
 scroll_active = false
 theme_override_fonts/normal_font = ExtResource("2_font")
 theme_override_font_sizes/normal_font_size = 20
+
+[node name="TauntPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_taunt")

--- a/UI/start_screen.gd
+++ b/UI/start_screen.gd
@@ -1,35 +1,55 @@
 extends Control
 ## Start Screen - Shown on game launch before any level loads.
 ## Emits `start_requested` when Space is pressed, or `level_select_requested`
-## when L is pressed.
+## when L is pressed. Q shows a quit confirmation (Y/N).
 
 signal start_requested
 signal level_select_requested
 
+@onready var prompt_panel: PanelContainer = $Content/PromptPanel
 @onready var prompt_label: RichTextLabel = $Content/PromptPanel/PromptLabel
+@onready var confirm_panel: PanelContainer = $Content/ConfirmPanel
 
 var _tween: Tween
+var _confirming_quit: bool = false
 
 func _unhandled_input(event: InputEvent) -> void:
 	if not visible:
 		return
+
+	if not event is InputEventKey or not event.pressed:
+		return
+
+	if _confirming_quit:
+		if event.keycode == KEY_Y:
+			get_tree().quit()
+		elif event.keycode == KEY_N or event.is_action_pressed("pause"):
+			_set_confirming(false)
+		get_viewport().set_input_as_handled()
+		return
+
 	# "confirm_bits" is already mapped to Space in the project input map.
 	if event.is_action_pressed("confirm_bits"):
 		start_requested.emit()
-		# Mark the input as handled so it doesn't propagate to other nodes
-		# (e.g. the HUD trying to submit bits).
 		get_viewport().set_input_as_handled()
 		return
 
 	# L key opens the level select screen.
-	if event is InputEventKey and event.pressed and event.keycode == KEY_L:
+	if event.keycode == KEY_L:
 		level_select_requested.emit()
+		get_viewport().set_input_as_handled()
+		return
+
+	# Q key shows quit confirmation.
+	if event.keycode == KEY_Q:
+		_set_confirming(true)
 		get_viewport().set_input_as_handled()
 
 ## Called by game.gd (via visibility) to start the pulse animation.
 ## The tween only runs while the screen is actually visible.
 func show_screen() -> void:
 	visible = true
+	_set_confirming(false)
 	_start_pulse()
 
 func hide_screen() -> void:
@@ -48,3 +68,9 @@ func _start_pulse() -> void:
 	# takes 0.8 seconds, giving a steady ~1.6 second breathing cycle.
 	_tween.tween_property(prompt_label, "modulate:a", 0.3, 0.8)
 	_tween.tween_property(prompt_label, "modulate:a", 1.0, 0.8)
+
+## Toggle between the normal prompt and the quit confirmation.
+func _set_confirming(confirming: bool) -> void:
+	_confirming_quit = confirming
+	prompt_panel.visible = not confirming
+	confirm_panel.visible = confirming

--- a/UI/start_screen.tscn
+++ b/UI/start_screen.tscn
@@ -54,7 +54,22 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_prompt")
 layout_mode = 2
 bbcode_enabled = true
 text = "[center][color=#00ff66][SPACE] Start
-[L] Level Select[/color][/center]"
+[L] Level Select
+[Q] Quit[/color][/center]"
+fit_content = true
+scroll_active = false
+theme_override_fonts/normal_font = ExtResource("3_font")
+theme_override_font_sizes/normal_font_size = 24
+
+[node name="ConfirmPanel" type="PanelContainer" parent="Content"]
+visible = false
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_prompt")
+
+[node name="ConfirmHint" type="RichTextLabel" parent="Content/ConfirmPanel"]
+layout_mode = 2
+bbcode_enabled = true
+text = "[center][color=#00ff66]Quit? [Y] Yes  [N] No[/color][/center]"
 fit_content = true
 scroll_active = false
 theme_override_fonts/normal_font = ExtResource("3_font")

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://cj4tufd00rsoa"]
 
-[ext_resource type="Script" uid="uid://sp317vu7cii0" path="res://scripts/game.gd" id="1_game"]
+[ext_resource type="Script" uid="uid://c73lgindfde0v" path="res://scripts/game.gd" id="1_game"]
 [ext_resource type="PackedScene" uid="uid://xegecis5ij0a" path="res://scenes/gameplay/game_00.tscn" id="2_0tnpc"]
 [ext_resource type="PackedScene" uid="uid://bq8b1hv10jtr0" path="res://scenes/gameplay/game_01.tscn" id="2_g01"]
 [ext_resource type="PackedScene" uid="uid://bl0n0th1n7nro" path="res://scenes/gameplay/game_03.tscn" id="3_g02"]
@@ -8,14 +8,14 @@
 [ext_resource type="PackedScene" uid="uid://bq06rlnqhphw5" path="res://scenes/gameplay/game_04.tscn" id="5_iywne"]
 [ext_resource type="PackedScene" uid="uid://cbtr4ckgkrn4y" path="res://scenes/gameplay/game_05.tscn" id="6_g05"]
 [ext_resource type="PackedScene" uid="uid://clpcwb8xlc0b2" path="res://scenes/gameplay/game_enemy2.tscn" id="7_0tnpc"]
-[ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="7_hud"]
-[ext_resource type="PackedScene" path="res://UI/start_screen.tscn" id="8_start"]
-[ext_resource type="PackedScene" path="res://UI/level_select_screen.tscn" id="8_lvlsel"]
-[ext_resource type="PackedScene" path="res://UI/pause_screen.tscn" id="9_pause"]
-[ext_resource type="PackedScene" path="res://UI/end_screen.tscn" id="10_end"]
 [ext_resource type="AudioStream" uid="uid://c1lldbd5nb7qb" path="res://sound/20260129_Digital Hell.wav" id="7_p57ef"]
 [ext_resource type="PackedScene" uid="uid://0vlvvya72vma" path="res://scenes/gameplay/game_enemy1.tscn" id="7_vtaks"]
 [ext_resource type="PackedScene" uid="uid://je365axajd6c" path="res://scenes/gameplay/game_06.tscn" id="8_kvpfn"]
+[ext_resource type="PackedScene" path="res://UI/level_select_screen.tscn" id="8_lvlsel"]
+[ext_resource type="PackedScene" path="res://UI/start_screen.tscn" id="8_start"]
+[ext_resource type="PackedScene" path="res://UI/pause_screen.tscn" id="9_pause"]
+[ext_resource type="PackedScene" path="res://UI/end_screen.tscn" id="10_end"]
+[ext_resource type="PackedScene" uid="uid://t3wnpot2m1d2" path="res://UI/hud_UI.tscn" id="16_rysoc"]
 
 [node name="Game" type="Node" unique_id=1282430220]
 script = ExtResource("1_game")
@@ -26,15 +26,23 @@ level_scenes = Array[PackedScene]([ExtResource("2_0tnpc"), ExtResource("2_g01"),
 [node name="UILayer" type="CanvasLayer" parent="." unique_id=21999873]
 layer = 10
 
-[node name="StartScreen" parent="UILayer" instance=ExtResource("8_start")]
+[node name="StartScreen" parent="UILayer" unique_id=1832729568 instance=ExtResource("8_start")]
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="LevelSelectScreen" parent="UILayer" instance=ExtResource("8_lvlsel")]
+[node name="LevelSelectScreen" parent="UILayer" unique_id=59805782 instance=ExtResource("8_lvlsel")]
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="PauseScreen" parent="UILayer" instance=ExtResource("9_pause")]
+[node name="PauseScreen" parent="UILayer" unique_id=1565705978 instance=ExtResource("9_pause")]
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="EndScreen" parent="UILayer" instance=ExtResource("10_end")]
+[node name="EndScreen" parent="UILayer" unique_id=408519661 instance=ExtResource("10_end")]
+grow_horizontal = 2
+grow_vertical = 2
 
-[node name="HudUi" parent="UILayer" instance=ExtResource("7_hud")]
+[node name="HudUi" parent="UILayer" unique_id=541352385 instance=ExtResource("16_rysoc")]
 grow_horizontal = 2
 grow_vertical = 2
 ui_scale = 1.2

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -23,6 +23,7 @@ var _current_level_instance: Node = null
 @onready var level_select_screen: Control = $UILayer/LevelSelectScreen
 @onready var pause_screen: Control = $UILayer/PauseScreen
 @onready var end_screen: Control = $UILayer/EndScreen
+@onready var bgm: AudioStreamPlayer = $AudioStreamPlayer
 
 func _ready() -> void:
 	GameManager.level_completed.connect(_on_level_completed)
@@ -148,9 +149,12 @@ func _update_ui_for_state(state: GameState) -> void:
 	level_select_screen.hide_screen()
 
 	if state == GameState.GAME_OVER:
+		bgm.stop()
 		end_screen.show_screen()
 	else:
 		end_screen.hide_screen()
+		if not bgm.playing:
+			bgm.play()
 
 	hud_ui.visible = (state == GameState.PLAYING)
 	# Disable HUD input processing when not playing so A/S/D/F/Tab/Space

--- a/sound/20260131_DAEMON's Taunt.wav.import
+++ b/sound/20260131_DAEMON's Taunt.wav.import
@@ -1,0 +1,24 @@
+[remap]
+
+importer="wav"
+type="AudioStreamWAV"
+uid="uid://c487ib3p77xv1"
+path="res://.godot/imported/20260131_DAEMON's Taunt.wav-0c17222ee209e4b12e424207ff97b9f2.sample"
+
+[deps]
+
+source_file="res://sound/20260131_DAEMON's Taunt.wav"
+dest_files=["res://.godot/imported/20260131_DAEMON's Taunt.wav-0c17222ee209e4b12e424207ff97b9f2.sample"]
+
+[params]
+
+force/8_bit=false
+force/mono=false
+force/max_rate=false
+force/max_rate_hz=44100
+edit/trim=false
+edit/normalize=false
+edit/loop_mode=0
+edit/loop_begin=0
+edit/loop_end=-1
+compress/mode=2


### PR DESCRIPTION
## Summary

- Play DAEMON's Taunt sound on end screen, pausing the background music during game over and resuming on state change
- Add [Q] Quit option to start screen with a Y/N confirmation prompt (same dark panel background for readability)

## Test plan

- [ ] End screen plays taunt and background music stops
- [ ] Leaving end screen stops taunt and resumes background music
- [ ] [Q] on start screen shows quit confirmation with readable dark background
- [ ] [Y] quits the game, [N] or ESC cancels back to normal prompt